### PR TITLE
[feat] SettingPage 버튼 기능 구현

### DIFF
--- a/fourtoon-cookie/src/apis/member.ts
+++ b/fourtoon-cookie/src/apis/member.ts
@@ -31,3 +31,10 @@ export const patchMember = async (name: string, birth: LocalDate, gender: Gender
         throw new ApiError("patchMember error");
     }
 }
+
+export const deleteMember = async (jwtContext: GlobalJwtTokenStateContextProps) => {
+    const response = await requestApi(`/member`, 'DELETE', jwtContext);
+    if (response.status != 204) {
+        throw new ApiError("deleteMember error");
+    }
+}

--- a/fourtoon-cookie/src/components/global/GlobalJwtToken/GlobalJwtTokenStateProvider.tsx
+++ b/fourtoon-cookie/src/components/global/GlobalJwtToken/GlobalJwtTokenStateProvider.tsx
@@ -56,7 +56,7 @@ const GlobalJwtTokenStateProvider = (props: GlobalJwtTokenStateProviderProps) =>
                 await AsyncStorage.removeItem('jwtToken');
                 setErrorInfo({
                     type: GlobalErrorInfoType.MODAL,
-                    error: new JwtError("인증 정보가 없습니다.")
+                    error: new JwtError("로그아웃 되었습니다.")
                 });
             }
             setJwtTokenState(jwtToken);

--- a/fourtoon-cookie/src/constants/constants.ts
+++ b/fourtoon-cookie/src/constants/constants.ts
@@ -1,2 +1,3 @@
 
 
+export const INQRUITY_PAGE_URL = "https://lateral-hockey-e66.notion.site/fourtoon-cookie-06fb780718cb484388ab753fafa87fd5?pvs=74";

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
@@ -2,14 +2,16 @@ import { View, Text, TouchableOpacity, Image, Linking } from 'react-native';
 import * as S from './MenuLayout.styled';
 import MenuItem from './MenuItem/MenuItem';
 import { INQRUITY_PAGE_URL } from '../../../constants/constants';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import GlobalErrorInfoStateContext from '../../../components/global/GlobalError/GlobalErrorInfoStateContext';
 import { GlobalErrorInfoType } from '../../../types/error';
 import GlobalJwtTokenStateContext from '../../../components/global/GlobalJwtToken/GlobalJwtTokenStateContext';
+import ResignModal from './ResignModal/ResignModal';
 
 const MenuLayout = () => {
     const { errorInfo, setErrorInfo } = useContext(GlobalErrorInfoStateContext);
     const { jwtToken, setJwtToken } = useContext(GlobalJwtTokenStateContext);
+    const [ isModalVisible, setIsModalVisible ] = useState(false);
 
     const handleInquiry = () => {
         Linking.openURL(INQRUITY_PAGE_URL).catch(err => 
@@ -24,16 +26,24 @@ const MenuLayout = () => {
         setJwtToken(null);
     }
 
-    const handleResign = () => {
-        //TODO: 회원 탈퇴 로직 구현
+    const handleResignButtonPress = () => {
+        setIsModalVisible(true);
+    }
+
+    const handleResignModelClose = () => {
+        setIsModalVisible(false);
     }
     
     return (
         <View style={S.styles.menuContainer}>
             <MenuItem menuText='문의하기' onPress={handleInquiry} />
             <MenuItem menuText='로그아웃' onPress={handleLogout} />
-            <MenuItem menuText='탈퇴하기' onPress={handleResign} textStyle={S.styles.deleteText} />
-      </View>
+            <MenuItem menuText='탈퇴하기' onPress={handleResignButtonPress} textStyle={S.styles.deleteText} />
+            <ResignModal
+                visible={isModalVisible}
+                onClose={handleResignModelClose}
+            />
+        </View>
     );
 }
 

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
@@ -1,10 +1,21 @@
-import { View, Text, TouchableOpacity, Image } from 'react-native';
+import { View, Text, TouchableOpacity, Image, Linking } from 'react-native';
 import * as S from './MenuLayout.styled';
 import MenuItem from './MenuItem/MenuItem';
+import { INQRUITY_PAGE_URL } from '../../../constants/constants';
+import { useContext } from 'react';
+import GlobalErrorInfoStateContext from '../../../components/global/GlobalError/GlobalErrorInfoStateContext';
+import { GlobalErrorInfoType } from '../../../types/error';
 
 const MenuLayout = () => {
+    const { errorInfo, setErrorInfo } = useContext(GlobalErrorInfoStateContext);
+
     const handleInquiry = () => {
-        //TODO: 문의하기 로직 구현
+        Linking.openURL(INQRUITY_PAGE_URL).catch(err => 
+            setErrorInfo({
+                type: GlobalErrorInfoType.MODAL,
+                error: new Error("문의 페이지로 이동하는데 실패했습니다."),
+            })
+        );
     }
 
     const handleLogout = () => {

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
@@ -1,5 +1,4 @@
-import { View, Text, TouchableOpacity, Image, Linking } from 'react-native';
-import * as S from './MenuLayout.styled';
+import { View, Linking } from 'react-native';
 import MenuItem from './MenuItem/MenuItem';
 import { INQRUITY_PAGE_URL } from '../../../constants/constants';
 import { useContext, useState } from 'react';
@@ -7,6 +6,7 @@ import GlobalErrorInfoStateContext from '../../../components/global/GlobalError/
 import { GlobalErrorInfoType } from '../../../types/error';
 import GlobalJwtTokenStateContext from '../../../components/global/GlobalJwtToken/GlobalJwtTokenStateContext';
 import ResignModal from './ResignModal/ResignModal';
+import * as S from './MenuLayout.styled';
 
 const MenuLayout = () => {
     const { errorInfo, setErrorInfo } = useContext(GlobalErrorInfoStateContext);

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/MenuLayout.tsx
@@ -5,9 +5,11 @@ import { INQRUITY_PAGE_URL } from '../../../constants/constants';
 import { useContext } from 'react';
 import GlobalErrorInfoStateContext from '../../../components/global/GlobalError/GlobalErrorInfoStateContext';
 import { GlobalErrorInfoType } from '../../../types/error';
+import GlobalJwtTokenStateContext from '../../../components/global/GlobalJwtToken/GlobalJwtTokenStateContext';
 
 const MenuLayout = () => {
     const { errorInfo, setErrorInfo } = useContext(GlobalErrorInfoStateContext);
+    const { jwtToken, setJwtToken } = useContext(GlobalJwtTokenStateContext);
 
     const handleInquiry = () => {
         Linking.openURL(INQRUITY_PAGE_URL).catch(err => 
@@ -19,7 +21,7 @@ const MenuLayout = () => {
     }
 
     const handleLogout = () => {
-        //TODO: 로그아웃 로직 구현
+        setJwtToken(null);
     }
 
     const handleResign = () => {

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/ResignModal/ResignModal.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/ResignModal/ResignModal.tsx
@@ -1,0 +1,30 @@
+import { useContext } from "react";
+import ConfirmationModal from "../../../../components/common/Modal/ConfirmationModal/ConfirmationModal"
+import GlobalJwtTokenStateContext from "../../../../components/global/GlobalJwtToken/GlobalJwtTokenStateContext";
+import { deleteMember } from "../../../../apis/member";
+
+export interface ResignModalProps {
+    visible: boolean;
+    onClose: () => void;
+}
+
+const ResignModal = (props: ResignModalProps) => {
+    const { visible, onClose } = props;
+    const jwtContext = useContext(GlobalJwtTokenStateContext);
+
+    const handleResign = () => {
+        deleteMember(jwtContext);
+        jwtContext.setJwtToken(null);
+    }
+
+    return (
+        <ConfirmationModal
+            visible={visible}
+            onClose={onClose}
+            onConfirm={handleResign}
+            message="정말 탈퇴하시겠습니까?"
+        />
+    );
+}
+
+export default ResignModal;

--- a/fourtoon-cookie/src/pages/SettingPage/MenuLayout/ResignModal/ResignModal.tsx
+++ b/fourtoon-cookie/src/pages/SettingPage/MenuLayout/ResignModal/ResignModal.tsx
@@ -2,6 +2,8 @@ import { useContext } from "react";
 import ConfirmationModal from "../../../../components/common/Modal/ConfirmationModal/ConfirmationModal"
 import GlobalJwtTokenStateContext from "../../../../components/global/GlobalJwtToken/GlobalJwtTokenStateContext";
 import { deleteMember } from "../../../../apis/member";
+import GlobalErrorInfoStateContext from "../../../../components/global/GlobalError/GlobalErrorInfoStateContext";
+import { GlobalErrorInfoType } from "../../../../types/error";
 
 export interface ResignModalProps {
     visible: boolean;
@@ -10,11 +12,23 @@ export interface ResignModalProps {
 
 const ResignModal = (props: ResignModalProps) => {
     const { visible, onClose } = props;
+
+    const { errorInfo, setErrorInfo } = useContext(GlobalErrorInfoStateContext);
     const jwtContext = useContext(GlobalJwtTokenStateContext);
 
-    const handleResign = () => {
-        deleteMember(jwtContext);
-        jwtContext.setJwtToken(null);
+    const handleResign = async () => {
+        try {
+            onClose();
+            await deleteMember(jwtContext);
+            jwtContext.setJwtToken(null);
+        } catch (error) {
+            if (error instanceof Error) {
+                setErrorInfo({
+                    type: GlobalErrorInfoType.MODAL,
+                    error: error,
+                });
+            }
+        }
     }
 
     return (


### PR DESCRIPTION
### Pull Request 타입
- [ ] bug (버그수정)
- [x] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-251
---
* 구현 내용
SettingPage에서 버튼 기능들을 추가해주었습니다.

1. 문의하기 로직 (바로 저희가 지정한 웹사이트로 라우팅이 됩니다.)
2. 로그아웃 로직 (jwtToken을 바로 null로 설정합니다.)
3. 탈퇴하기 로직 (팝업이 표시된 이후 확인이 된다면 [delete] /member API 요청이 가고 jwtToken을 바로 null로 설정합니다.)

* 추가 발생한 문제(논의 사항)
1. 에러 메시지나 컴포넌트 내 문자들을 관리하는 방침이 필요해보이긴 합니다.
2. 문의하기에서 라우팅할 홈페이지 url을 수정해야 합니다.

### 화면 예시
---
기존 세팅 페이지와 동일한 디자인으로 진행하여 생략하겠습니다.