### PR TITLE
[refactor] patchMember를 postMember 로 변경

### DIFF
--- a/fourtoon-cookie/src/apis/member.ts
+++ b/fourtoon-cookie/src/apis/member.ts
@@ -19,15 +19,15 @@ export const getMember = async (jwtContext: GlobalJwtTokenStateContextProps): Pr
 
 }
 
-export const patchMember = async (name: string, birth: LocalDate, gender: Gender, jwtContext: GlobalJwtTokenStateContextProps) => {
+export const postMember = async (name: string, birth: LocalDate, gender: Gender, jwtContext: GlobalJwtTokenStateContextProps) => {
     const requestBody: MemberSaveRequest = {
         name: name,
         birth: birth,
         gender: gender
     };
 
-    const response = await requestApi(`/member`, 'PATCH', jwtContext, requestBody);
-    if (response.status != 200) {
+    const response = await requestApi(`/member`, 'POST', jwtContext, requestBody);
+    if (response.status != 201) {
         throw new ApiError("회원가입 중 오류가 발생했습니다.");
     }
 }

--- a/fourtoon-cookie/src/apis/member.ts
+++ b/fourtoon-cookie/src/apis/member.ts
@@ -1,6 +1,6 @@
 import { API_URL } from "@env";
 import { GlobalJwtTokenStateContextProps } from "../components/global/GlobalJwtToken/GlobalJwtTokenStateContext";
-import type { MemberSavedResponse, MemberUpdateRequest } from "../types/dto/member";
+import type { MemberSavedResponse, MemberSaveRequest } from "../types/dto/member";
 import { Gender } from "../types/gender";
 import { requestApi } from "./api";
 import type { Member } from "../types/member";
@@ -20,7 +20,7 @@ export const getMember = async (jwtContext: GlobalJwtTokenStateContextProps): Pr
 }
 
 export const patchMember = async (name: string, birth: LocalDate, gender: Gender, jwtContext: GlobalJwtTokenStateContextProps) => {
-    const requestBody: MemberUpdateRequest = {
+    const requestBody: MemberSaveRequest = {
         name: name,
         birth: birth,
         gender: gender

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -11,7 +11,7 @@ import GenderInputLayout from "./GenderInputLayout/GenderInputLayout";
 import { NavigationProp, useNavigation } from "@react-navigation/native";
 import { RootStackParamList } from "../../constants/routing";
 import GlobalJwtTokenStateContext from "../../components/global/GlobalJwtToken/GlobalJwtTokenStateContext";
-import { patchMember } from "../../apis/member";
+import { postMember } from "../../apis/member";
 import { LocalDate } from "@js-joda/core";
 import GlobalErrorInfoStateContext from "../../components/global/GlobalError/GlobalErrorInfoStateContext";
 import { GlobalErrorInfoType } from "../../types/error";
@@ -74,7 +74,7 @@ const SignUpPage = () => {
             if (! gender) return;
 
             try {
-                patchMember(name, birth, gender, jwtContext);
+                postMember(name, birth, gender, jwtContext);
                 navigation.navigate('DiaryTimelinePage');
             } catch (error) {
                 if (error instanceof Error) {

--- a/fourtoon-cookie/src/types/dto/member.ts
+++ b/fourtoon-cookie/src/types/dto/member.ts
@@ -8,6 +8,7 @@ export interface MemberSaveRequest {
 }
 
 export interface MemberSavedResponse {
+    email: string;
     name: string;
     gender: string;
     birth: LocalDate;

--- a/fourtoon-cookie/src/types/dto/member.ts
+++ b/fourtoon-cookie/src/types/dto/member.ts
@@ -1,7 +1,7 @@
 import { LocalDate } from "@js-joda/core";
 
 
-export interface MemberUpdateRequest {
+export interface MemberSaveRequest {
     name: string;
     birth: LocalDate;
     gender: string;

--- a/fourtoon-cookie/src/types/dto/member.ts
+++ b/fourtoon-cookie/src/types/dto/member.ts
@@ -8,7 +8,6 @@ export interface MemberSaveRequest {
 }
 
 export interface MemberSavedResponse {
-    email: string;
     name: string;
     gender: string;
     birth: LocalDate;

--- a/fourtoon-cookie/src/types/member.ts
+++ b/fourtoon-cookie/src/types/member.ts
@@ -2,6 +2,7 @@ import { LocalDate } from "@js-joda/core"
 
 export interface Member {
     name: string,
+    email: string,
     gender: string,
     birth: LocalDate
 };

--- a/fourtoon-cookie/src/types/member.ts
+++ b/fourtoon-cookie/src/types/member.ts
@@ -2,7 +2,6 @@ import { LocalDate } from "@js-joda/core"
 
 export interface Member {
     name: string,
-    email: string,
     gender: string,
     birth: LocalDate
 };


### PR DESCRIPTION
### [refactor] MemberUpdateRequest → MemberSaveRequest 로 변경
- [ ] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [x] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-281
---
이전에 슈펴베이스 auth 테이블에 멤버를 저장후 트리거를 통해 RDS member 테이블에 저장 후 member 테이블 컬럼 pathch 했던 부분을
슈퍼베이스 auth 테이블에만 저장하고, RDS member 테이블을 별도로 관리하므로 put으로 변경
=> update에서 save로 변경 (memberUpdateRequest -> memberSaveRequest)
