### PR TITLE
[fix] SignUpPage에서 백버튼 동작 로직 수정

### DIFF
--- a/fourtoon-cookie/src/components/common/BackButton/BackButton.tsx
+++ b/fourtoon-cookie/src/components/common/BackButton/BackButton.tsx
@@ -4,14 +4,19 @@ import * as S from './BackButton.styled';
 import {useNavigation} from "@react-navigation/native";
 
 export interface BackButtonProps {
+    onPress?: () => void;
     style?: StyleProp<ViewStyle>;
 }
 
 const BackButton = (props: BackButtonProps) => {
-    const {style, ...rest} = props;
+    const {onPress, style, ...rest} = props;
     const navigation = useNavigation();
 
     const handlePress = () => {
+        if (onPress){
+            onPress();
+            return;
+        }
         navigation.goBack();
     }
 

--- a/fourtoon-cookie/src/pages/SignUpPage/Header/Header.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/Header/Header.tsx
@@ -2,10 +2,16 @@ import { Text, View } from "react-native";
 import BackButton from "../../../components/common/BackButton/BackButton"
 import * as S from "./Header.styled";
 
-const Header = () => {
+export interface HeaderProps {
+    onBackButtonPress: () => void
+}
+
+const Header = (props: HeaderProps) => {
+    const { onBackButtonPress, ...rest } = props;
+
     return (
         <View style={S.styles.header}>
-            <BackButton style={S.styles.backButton} />
+            <BackButton onPress={onBackButtonPress} style={S.styles.backButton} />
             <Text style={S.styles.headerText}>회원가입</Text>
         </View>
     );

--- a/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
+++ b/fourtoon-cookie/src/pages/SignUpPage/SignUpPage.tsx
@@ -65,6 +65,16 @@ const SignUpPage = () => {
         setGender(gender);
     }
 
+    const handleBackButtonPress = () => {
+        if (signUpProgress == SignUpProgres.NAME) {
+            jwtContext.setJwtToken(null);
+            navigation.goBack();
+            return;
+        }
+
+        setSignUpProgress(signUpProgress - 1);
+    }
+
     const handleNextButtonClick = () => {
         if (! isNextButtonAvailabe) return;
 
@@ -90,7 +100,7 @@ const SignUpPage = () => {
     return (
         <SafeAreaView style={S.styles.safeArea}>
             <View style={S.styles.container}>
-                <Header />
+                <Header onBackButtonPress={handleBackButtonPress}/>
                 {
                     signUpProgress == SignUpProgres.NAME && 
                     <Container title="당신의 이름을 알려주세요">


### PR DESCRIPTION
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-291
---
* 구현 내용
SignUpPage(회원가입 페이지)에서 

기존: 백버튼을 누르면 이전 "페이지"인 "IntroPage"로 감

수정: 백버튼을 누르면 이전 단계로 넘어감 (단, Name -> Birth -> Gender 순서이기에 Name을 적는 칸에서 누를 경우에는 IntroPage로 감)

* 추가 발생한 문제(논의 사항)
아무래도 JWT 관련 로직을 빠르게 수정하는 편이 좋을 듯 합니다.
작동은 되나, JWT 에러 핸들링이 여러 곳곳에서 되는 느낌이어서 이를 정제할 필요가 있어보입니다.
(현재는 api.ts, GlobalJWT, GlobalError에서 관리하여 겹치는 구간이 발생함)
