### PR TITLE
[fix] IntroPage에서 member get을 통해 회원가입 여부를 따지는 로직의 결함을 수정함.

### DIFF
--- a/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
+++ b/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
@@ -19,7 +19,7 @@ const IntroPage = () => {
     
     const navigateByCheckingMemberExist = async () => {
         try {
-            const member: Member = await getMember();
+            await getMember();
             navigation.navigate('DiaryTimelinePage');
         } catch (error) {
             if (error instanceof ApiError && error.getStatus() === 404) {

--- a/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
+++ b/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
@@ -11,6 +11,7 @@ import GlobalErrorInfoStateContext from "../../components/global/GlobalError/Glo
 import { GlobalErrorInfoType } from "../../types/error";
 import AppleSignInAndSignUpButton from "./AppleSignInAndSignUpButton/AppleSignInAndSignUpButton";
 import { jwtManager } from "../../auth/jwt";
+import { ApiError } from "../../error/ApiError";
 
 const IntroPage = () => {
     const navigation = useNavigation<NavigationProp<RootStackParamList>>();
@@ -19,12 +20,13 @@ const IntroPage = () => {
     const navigateByCheckingMemberExist = async () => {
         try {
             const member: Member = await getMember();
-            if (member.name == null) {
-                navigation.navigate('SignUpPage');
-            } else {
-                navigation.navigate('DiaryTimelinePage');
-            }
+            navigation.navigate('DiaryTimelinePage');
         } catch (error) {
+            if (error instanceof ApiError && error.getStatus() === 404) {
+                navigation.navigate('SignUpPage');
+                return;
+            }
+            
             if (error instanceof Error) {
                 setErrorInfo({
                     type: GlobalErrorInfoType.MODAL,

--- a/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
+++ b/fourtoon-cookie/src/pages/IntroPage/IntroPage.tsx
@@ -28,6 +28,7 @@ const IntroPage = () => {
             }
             
             if (error instanceof Error) {
+                jwtManager.setToken(null);
                 setErrorInfo({
                     type: GlobalErrorInfoType.MODAL,
                     error: error


### PR DESCRIPTION
### Pull Request 타입
- [x] bug (버그수정)
- [ ] feat (기능)
- [ ] style (코드 스타일 수정)
- [ ] refactor(기능 변경 없는 수정)
- [ ] build (빌드)
- [ ] CI/CD (배포)
- [ ] doc (문서화)
- [ ] chore (간단한 수정)
- [ ] merge (병합)

### TSK-300
---
* 구현 내용

IntroPage에서..
1. 회원가입이 안 된 경우 [GET] /member가 404 에러를 보내는 것을 확인해서 SignUpPage로 리다이렉트 되도록 수정함.

2. 만약 navigateByCheckingMemberExist 중 오류가 발생하면 jwt를 null로 설정함.
(이를 통해 무한 로딩 문제를 해결)